### PR TITLE
Free sam from the shackles of automated PR assignments

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -32,7 +32,7 @@ jobs:
           base: main
           title: Release ${{ steps.version.outputs.next_tag }}
           labels: chore
-          reviewers: krivard,sgratzl
-          assignees: sgratzl
+          reviewers: krivard
+          assignees: krivard
           body: |
             Releasing ${{ steps.version.outputs.next_tag }}.


### PR DESCRIPTION
I noticed at the last release that the system still auto-assigns sam to release PRs -- no longer necessary.