### PR TITLE
Update workflows for Katie's departure

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -32,7 +32,7 @@ jobs:
           base: main
           title: Release ${{ steps.version.outputs.next_tag }}
           labels: chore
-          # reviewers: 
+          # reviewers:
           assignees: melange396
           body: |
             Releasing ${{ steps.version.outputs.next_tag }}.

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -32,7 +32,7 @@ jobs:
           base: main
           title: Release ${{ steps.version.outputs.next_tag }}
           labels: chore
-          reviewers: krivard
-          assignees: krivard
+          # reviewers: 
+          assignees: melange396
           body: |
             Releasing ${{ steps.version.outputs.next_tag }}.

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -96,7 +96,7 @@ jobs:
           commit-message: 'feat: update to EPIVis ${{ needs.create_release.outputs.tag_name }}'
           title: 'update to EPIVis ${{ needs.create_release.outputs.tag_name }}'
           labels: feat
-          # reviewers: 
+          # reviewers:
           assignees: melange396
           body: |
             update to [EPIVis ${{ needs.create_release.outputs.tag_name }}](https://github.com/cmu-delphi/www-epivis/releases/${{ needs.create_release.outputs.tag_name }})
@@ -123,7 +123,7 @@ jobs:
           base: dev
           title: 'chore: sync main->dev'
           labels: chore
-          # reviewers: 
+          # reviewers:
           assignees: melange396
           body: |
             Syncing Main->Dev.

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -96,8 +96,8 @@ jobs:
           commit-message: 'feat: update to EPIVis ${{ needs.create_release.outputs.tag_name }}'
           title: 'update to EPIVis ${{ needs.create_release.outputs.tag_name }}'
           labels: feat
-          reviewers: krivard
-          assignees: krivard
+          # reviewers: 
+          assignees: melange396
           body: |
             update to [EPIVis ${{ needs.create_release.outputs.tag_name }}](https://github.com/cmu-delphi/www-epivis/releases/${{ needs.create_release.outputs.tag_name }})
 
@@ -123,7 +123,7 @@ jobs:
           base: dev
           title: 'chore: sync main->dev'
           labels: chore
-          reviewers: krivard
-          assignees: krivard
+          # reviewers: 
+          assignees: melange396
           body: |
             Syncing Main->Dev.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "eslint src --ext .ts,.js,.svelte && prettier --check \"**/*\"",
     "fix": "eslint src --ext .ts,.js,.svelte --fix && prettier --write \"**/*\"",
     "prepare": "husky install",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "prettier": "prettier --write \"**/*\""
   },
   "devDependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.1.2",


### PR DESCRIPTION
Tag george instead of Katie; assign instead of review. Reviews are handled through the release-runner rotation.