### PR TITLE
update hostname for epidata api

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [context.production.environment]
-  EPIDATA_ENDPOINT_URL = "https://api.covidcast.cmu.edu/epidata"
+  EPIDATA_ENDPOINT_URL = "https://api.delphi.cmu.edu/epidata"
 
 [context.branch-deploy.environment]
-  EPIDATA_ENDPOINT_URL = "https://api.covidcast.cmu.edu/epidata"
+  EPIDATA_ENDPOINT_URL = "https://api.delphi.cmu.edu/epidata"
 
 [context.deploy-preview.environment]
-  EPIDATA_ENDPOINT_URL = "https://api.covidcast.cmu.edu/epidata"
+  EPIDATA_ENDPOINT_URL = "https://api.delphi.cmu.edu/epidata"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,7 @@ export default [
           'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development'),
           __VERSION__: JSON.stringify(pkg.version),
           'process.env.EPIDATA_ENDPOINT_URL': JSON.stringify(
-            process.env.EPIDATA_ENDPOINT_URL || 'https://api.covidcast.cmu.edu/epidata',
+            process.env.EPIDATA_ENDPOINT_URL || 'https://api.delphi.cmu.edu/epidata',
           ),
         },
         preventAssignment: true,


### PR DESCRIPTION
This replaces `api.covidcast.cmu.edu` with `api.delphi.cmu.edu`, as the endpoint is no longer intended to be covid-specific.  Both hostnames resolve to the same IP address (some day we will change this in DNS so `covidcast` is an alias of `delphi`, and not the other way around).