### PR TITLE
Improve handling for URL-based signals & support COVIDcast EpiWeeks

### DIFF
--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -34,7 +34,7 @@ export function epiRange(from: string | number, to: string | number): string {
 
 // find the current epiweek and date
 const date = new Date();
-const epidate = new EpiDate(date.getFullYear(), date.getMonth() + 1, date.getDate());
+const epidate = new EpiDate(date.getFullYear() + 1900, date.getMonth() + 1, date.getDate());
 export const currentEpiWeek = epidate.getEpiYear() * 100 + epidate.getEpiWeek();
 export const currentDate = epidate.getYear() * 10000 + epidate.getMonth() * 100 + epidate.getDay();
 

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -190,20 +190,17 @@ export function importCOVIDcast({
   geo_type: string;
   geo_value: string;
 }): Promise<DataGroup | null> {
-  const title = `[API] Delphi COVIDcast: ${geo_value} ${signal} (${data_source}) ${time_type}`;
-  console.log(epiRange(firstEpiWeek.covidcast, currentEpiWeek));
+  const title = `[API] COVIDcast: ${data_source}:${signal} (${geo_type}:${geo_value})`;
   return loadDataSet(
     title,
     'covidcast',
-    time_type === 'day'
-      ? {
-          time_type: 'day',
-          time_values: epiRange(firstDate.covidcast, currentDate),
-        }
-      : {
-          time_type: 'week',
-          time_values: epiRange(firstEpiWeek.covidcast, currentEpiWeek),
-        },
+    {
+      time_type: time_type,
+      time_values:
+        time_type === 'day'
+          ? epiRange(firstDate.covidcast, currentDate)
+          : epiRange(firstEpiWeek.covidcast, currentEpiWeek),
+    },
     { data_source, signal, time_type, geo_type, geo_value },
     ['value', 'stderr', 'sample_size'],
   );

--- a/src/components/dialogs/dataSources/COVIDcast.svelte
+++ b/src/components/dialogs/dataSources/COVIDcast.svelte
@@ -47,7 +47,11 @@
   });
 
   export function importDataSet() {
-    return importCOVIDcast({ data_source, signal, geo_type, geo_value });
+    return fetchCOVIDcastMeta().then((res) => {
+      const meta = res.filter((row) => row.data_source === data_source && row.signal === signal);
+      const time_type = meta[0].time_type || 'day';
+      return importCOVIDcast({ data_source, signal, geo_type, geo_value, time_type });
+    });
   }
 </script>
 

--- a/src/components/dialogs/dataSources/COVIDcast.svelte
+++ b/src/components/dialogs/dataSources/COVIDcast.svelte
@@ -49,7 +49,7 @@
   export function importDataSet() {
     return fetchCOVIDcastMeta().then((res) => {
       const meta = res.filter((row) => row.data_source === data_source && row.signal === signal);
-      const time_type = meta[0].time_type || 'day';
+      const time_type = meta[0].time_type;
       return importCOVIDcast({ data_source, signal, geo_type, geo_value, time_type });
     });
   }

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -385,6 +385,7 @@ export const firstEpiWeek = {
   quidel: 201535,
   sensors: 201030,
   nowcast: 200901,
+  covidcast: 202001,
 };
 
 // first available date for each data source

--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -158,9 +158,9 @@ export function initialLoader(datasets: ILinkConfig['datasets']) {
     return Promise.all(resolvedDataSets).then((data) => {
       const cleaned = data.filter((d): d is DataSet => d != null);
       cleaned.forEach((d) => {
-        if (d.params && !Array.isArray(d.params) && d.params._endpoint && d.params.regions) {
+        if (d.params) {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          d.title = `${d.params._endpoint} | ${d.params.regions} | ${d.title}`;
+          d.title = `${Object.values(d.params).join(' > ')} > ${d.title}`;
         }
         add(d);
       });

--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -158,9 +158,17 @@ export function initialLoader(datasets: ILinkConfig['datasets']) {
     return Promise.all(resolvedDataSets).then((data) => {
       const cleaned = data.filter((d): d is DataSet => d != null);
       cleaned.forEach((d) => {
-        if (d.params) {
+        if (d.params && !Array.isArray(d.params) && d.params._endpoint) {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          d.title = `${Object.values(d.params).join(' > ')} > ${d.title}`;
+          d.title = `${d.params._endpoint}`;
+          if (d.params.data_source && d.params.signal) {
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            d.title += ` > ${d.params.data_source}:${d.params.signal}`;
+          }
+          if (d.params.geo_type && d.params.geo_value) {
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            d.title += ` > ${d.params.geo_type}:${d.params.geo_value}`;
+          }
         }
         add(d);
       });

--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -159,16 +159,20 @@ export function initialLoader(datasets: ILinkConfig['datasets']) {
       const cleaned = data.filter((d): d is DataSet => d != null);
       cleaned.forEach((d) => {
         if (d.params && !Array.isArray(d.params) && d.params._endpoint) {
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          /* eslint-disable @typescript-eslint/restrict-template-expressions */
+          const col_name = d.title;
           d.title = `${d.params._endpoint}`;
           if (d.params.data_source && d.params.signal) {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             d.title += ` > ${d.params.data_source}:${d.params.signal}`;
           }
           if (d.params.geo_type && d.params.geo_value) {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             d.title += ` > ${d.params.geo_type}:${d.params.geo_value}`;
           }
+          if (d.params.regions) {
+            d.title += ` > ${d.params.regions}`;
+          }
+          d.title += ` > ${col_name}`;
+          /* eslint-enable @typescript-eslint/restrict-template-expressions */
         }
         add(d);
       });


### PR DESCRIPTION
Closes #43, partially addresses #42:

- URL-provided signals are given a title in the left-side panel based on their parameters (data source, signals, daily/weekly cadence etc.)
- Added support for COVIDCast signals with a weekly cadence. This is based on the `time_type` specified in the meta endpoint, and works for both URL-provided signals as well as those selected in the signal picker.