### PR TITLE
Improve top panel elements & autofit mode

### DIFF
--- a/src/components/Chart.svelte
+++ b/src/components/Chart.svelte
@@ -270,6 +270,9 @@
     dx = ((xMax - xMin) / 2) * fx;
     dy = ((yMax - yMin) / 2) * fy;
     setViewport(xMin - dx, yMin - dy, xMax - dx, yMax - dy);
+    if (navMode == NavMode.autofit) {
+      navMode = NavMode.pan;
+    }
   }
 
   function zoom(x: number, y: number): void {

--- a/src/components/Chart.svelte
+++ b/src/components/Chart.svelte
@@ -134,7 +134,9 @@
         setNavMode(NavMode.zoom);
       }
     }
-    if (navMode == NavMode.crop) {
+    if (navMode == NavMode.autofit) {
+      navMode = NavMode.pan;
+    } else if (navMode == NavMode.crop) {
       navBox = { x: m.x, y: m.y, w: 0, h: 0 };
     }
   }

--- a/src/components/TopMenu.svelte
+++ b/src/components/TopMenu.svelte
@@ -82,81 +82,6 @@
 </script>
 
 <div class="menu" {style} data-tour="top">
-  <div class="uk-button-group">
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      on:click|preventDefault={randomizeColors}
-      title="Randomize Colors<br/>(Keyboard Shortcut: r)"
-      data-tour="random"
-      uk-tooltip><Fa icon={faPaintBrush} /></button
-    >
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      disabled={!chart}
-      on:click|preventDefault={() => (chart ? chart.fitData(true) : null)}
-      title="Fit Data to Screen<br/>(Keyboard Shortcut: f)"
-      data-tour="fit"
-      uk-tooltip><Fa icon={faExpand} /></button
-    >
-
-    <button
-      type="button"
-      class="uk-button uk-button-small"
-      class:uk-active={$isShowingPoints}
-      class:uk-button-secondary={$isShowingPoints}
-      class:uk-button-default={!$isShowingPoints}
-      on:click|preventDefault={() => ($isShowingPoints = !$isShowingPoints)}
-      title="Show or Hide Points<br/>(Keyboard Shortcut: s)"
-      data-tour="points"
-      uk-tooltip><Fa icon={faEllipsisH} /></button
-    >
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      on:click|preventDefault={() => (doDialog = 'regress')}
-      title="Perform Regression"
-      uk-tooltip
-      disabled={$activeDatasets.length < 2}><Fa icon={faChartLine} /></button
-    >
-  </div>
-  <div class="uk-button-group">
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      on:click|preventDefault={scaleMean}
-      title="Scale by 1/mean"
-      uk-tooltip><Fa icon={faMinimize} /></button
-    >
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      on:click|preventDefault={reset}
-      title="Reset Dataset Scaling"
-      uk-tooltip><Fa icon={faShuffle} /></button
-    >
-  </div>
-  <div class="uk-button-group">
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      disabled={!chart}
-      title="Take a screenshot"
-      uk-tooltip
-      data-tour="screenshot"
-      on:click|preventDefault={takeScreenshot}><Fa icon={faImage} /></button
-    >
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      title="Link to this view"
-      disabled={!chart}
-      uk-tooltip
-      data-tour="link"
-      on:click|preventDefault={() => (doDialog = 'directLink')}><Fa icon={faLink} /></button
-    >
-  </div>
   <div class="uk-button-group" data-tour="navmode">
     <button
       type="button"
@@ -198,6 +123,81 @@
       title="Zoom Mode<br/>(Keyboard Shortcut: z)"
       uk-tooltip
       on:click|preventDefault={() => ($navMode = NavMode.zoom)}><Fa icon={faSearchPlus} /></button
+    >
+  </div>
+  <div class="uk-button-group">
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      on:click|preventDefault={randomizeColors}
+      title="Randomize Colors<br/>(Keyboard Shortcut: r)"
+      data-tour="random"
+      uk-tooltip><Fa icon={faPaintBrush} /></button
+    >
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      disabled={!chart}
+      on:click|preventDefault={() => (chart ? chart.fitData(true) : null)}
+      title="Fit Data to Screen<br/>(Keyboard Shortcut: f)"
+      data-tour="fit"
+      uk-tooltip><Fa icon={faExpand} /></button
+    >
+
+    <button
+      type="button"
+      class="uk-button uk-button-small"
+      class:uk-active={$isShowingPoints}
+      class:uk-button-secondary={$isShowingPoints}
+      class:uk-button-default={!$isShowingPoints}
+      on:click|preventDefault={() => ($isShowingPoints = !$isShowingPoints)}
+      title="Show or Hide Points<br/>(Keyboard Shortcut: s)"
+      data-tour="points"
+      uk-tooltip><Fa icon={faEllipsisH} /></button
+    >
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      on:click|preventDefault={() => (doDialog = 'regress')}
+      title="Perform Regression"
+      uk-tooltip
+      disabled={$activeDatasets.length < 2}><Fa icon={faChartLine} /></button
+    >
+  </div>
+  <div class="uk-button-group" data-tour="scale">
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      on:click|preventDefault={scaleMean}
+      title="Scale by 1/mean"
+      uk-tooltip><Fa icon={faMinimize} /></button
+    >
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      on:click|preventDefault={reset}
+      title="Reset Dataset Scaling"
+      uk-tooltip><Fa icon={faShuffle} /></button
+    >
+  </div>
+  <div class="uk-button-group">
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      disabled={!chart}
+      title="Take a screenshot"
+      uk-tooltip
+      data-tour="screenshot"
+      on:click|preventDefault={takeScreenshot}><Fa icon={faImage} /></button
+    >
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      title="Link to this view"
+      disabled={!chart}
+      uk-tooltip
+      data-tour="link"
+      on:click|preventDefault={() => (doDialog = 'directLink')}><Fa icon={faLink} /></button
     >
   </div>
   <div class="uk-button-group">

--- a/src/components/TopMenu.svelte
+++ b/src/components/TopMenu.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
   import {
+    faAnchor,
     faArrowsAlt,
     faChartLine,
     faCrop,
     faEllipsisH,
     faExpand,
     faImage,
-    faMinimize,
     faLink,
     faPaintBrush,
     faQuestion,
     faSearchPlus,
     faShuffle,
-    faUpDown,
   } from '@fortawesome/free-solid-svg-icons';
   import Fa from 'svelte-fa';
   import { activeDatasets, isShowingPoints, navMode, randomizeColors, reset, scaleMean } from '../store';
@@ -92,7 +91,7 @@
       class:uk-button-default={$navMode !== NavMode.autofit}
       on:click|preventDefault={() => ($navMode = NavMode.autofit)}
       title="Autofit Mode<br/>(Keyboard Shortcut: a)"
-      uk-tooltip><Fa icon={faUpDown} /></button
+      uk-tooltip><Fa icon={faExpand} /></button
     >
     <button
       type="button"
@@ -136,16 +135,6 @@
     >
     <button
       type="button"
-      class="uk-button uk-button-default uk-button-small"
-      disabled={!chart}
-      on:click|preventDefault={() => (chart ? chart.fitData(true) : null)}
-      title="Fit Data to Screen<br/>(Keyboard Shortcut: f)"
-      data-tour="fit"
-      uk-tooltip><Fa icon={faExpand} /></button
-    >
-
-    <button
-      type="button"
       class="uk-button uk-button-small"
       class:uk-active={$isShowingPoints}
       class:uk-button-secondary={$isShowingPoints}
@@ -170,7 +159,7 @@
       class="uk-button uk-button-default uk-button-small"
       on:click|preventDefault={scaleMean}
       title="Scale by 1/mean"
-      uk-tooltip><Fa icon={faMinimize} /></button
+      uk-tooltip><Fa icon={faAnchor} /></button
     >
     <button
       type="button"

--- a/src/components/TopMenu.svelte
+++ b/src/components/TopMenu.svelte
@@ -1,21 +1,21 @@
 <script lang="ts">
   import {
-    faAnchor,
     faArrowsAlt,
     faChartLine,
     faCrop,
     faEllipsisH,
     faExpand,
     faImage,
+    faMinimize,
     faLink,
     faPaintBrush,
     faQuestion,
-    faReceipt,
     faSearchPlus,
+    faShuffle,
     faUpDown,
   } from '@fortawesome/free-solid-svg-icons';
   import Fa from 'svelte-fa';
-  import { activeDatasets, isShowingPoints, navMode, randomizeColors, reset, scaleMean, autoFit } from '../store';
+  import { activeDatasets, isShowingPoints, navMode, randomizeColors, reset, scaleMean } from '../store';
   import type { IChart } from '../store';
   import { NavMode } from './chartUtils';
   import { tour } from '../tour';
@@ -55,6 +55,9 @@
           chart.fitData(true);
         }
         break;
+      case 'a':
+        $navMode = NavMode.autofit;
+        break;
       case 'p':
         $navMode = NavMode.pan;
         break;
@@ -69,9 +72,6 @@
         break;
       case 's':
         $isShowingPoints = !$isShowingPoints;
-        break;
-      case 'a':
-        $autoFit = !$autoFit;
         break;
       case 'h':
         tour.cancel();
@@ -100,18 +100,7 @@
       data-tour="fit"
       uk-tooltip><Fa icon={faExpand} /></button
     >
-    <button
-      type="button"
-      class="uk-button uk-button-small"
-      disabled={!chart}
-      class:uk-active={$autoFit}
-      class:uk-button-secondary={$autoFit}
-      class:uk-button-default={!$autoFit}
-      on:click|preventDefault={() => ($autoFit = !$autoFit)}
-      title="Automatically Fit Data<br/>(Keyboard Shortcut: a)"
-      data-tour="autofit"
-      uk-tooltip><Fa icon={faUpDown} /></button
-    >
+
     <button
       type="button"
       class="uk-button uk-button-small"
@@ -119,16 +108,9 @@
       class:uk-button-secondary={$isShowingPoints}
       class:uk-button-default={!$isShowingPoints}
       on:click|preventDefault={() => ($isShowingPoints = !$isShowingPoints)}
-      title="Show or Hide points<br/>(Keyboard Shortcut: s)"
+      title="Show or Hide Points<br/>(Keyboard Shortcut: s)"
       data-tour="points"
       uk-tooltip><Fa icon={faEllipsisH} /></button
-    >
-    <button
-      type="button"
-      class="uk-button uk-button-default uk-button-small"
-      on:click|preventDefault={scaleMean}
-      title="Scale by 1/mean"
-      uk-tooltip><Fa icon={faAnchor} /></button
     >
     <button
       type="button"
@@ -138,12 +120,21 @@
       uk-tooltip
       disabled={$activeDatasets.length < 2}><Fa icon={faChartLine} /></button
     >
+  </div>
+  <div class="uk-button-group">
+    <button
+      type="button"
+      class="uk-button uk-button-default uk-button-small"
+      on:click|preventDefault={scaleMean}
+      title="Scale by 1/mean"
+      uk-tooltip><Fa icon={faMinimize} /></button
+    >
     <button
       type="button"
       class="uk-button uk-button-default uk-button-small"
       on:click|preventDefault={reset}
-      title="Reset DataSet Scaling"
-      uk-tooltip><Fa icon={faReceipt} /></button
+      title="Reset Dataset Scaling"
+      uk-tooltip><Fa icon={faShuffle} /></button
     >
   </div>
   <div class="uk-button-group">
@@ -167,6 +158,17 @@
     >
   </div>
   <div class="uk-button-group" data-tour="navmode">
+    <button
+      type="button"
+      class="uk-button uk-button-small"
+      disabled={!chart}
+      class:uk-active={$navMode === NavMode.autofit}
+      class:uk-button-secondary={$navMode === NavMode.autofit}
+      class:uk-button-default={$navMode !== NavMode.autofit}
+      on:click|preventDefault={() => ($navMode = NavMode.autofit)}
+      title="Autofit Mode<br/>(Keyboard Shortcut: a)"
+      uk-tooltip><Fa icon={faUpDown} /></button
+    >
     <button
       type="button"
       class="uk-button uk-button-small"

--- a/src/components/chartUtils.ts
+++ b/src/components/chartUtils.ts
@@ -1,7 +1,8 @@
 export enum NavMode {
-  pan = 0,
-  crop = 1,
-  zoom = 2,
+  autofit = 0,
+  pan = 1,
+  crop = 2,
+  zoom = 3,
 }
 
 export enum Align {

--- a/src/components/dialogs/ImportAPIDialog.svelte
+++ b/src/components/dialogs/ImportAPIDialog.svelte
@@ -19,6 +19,8 @@
   import NowCast from './dataSources/Nowcast.svelte';
   import CovidHosp from './dataSources/COVIDHosp.svelte';
   import CoviDcast from './dataSources/COVIDcast.svelte';
+  import { navMode } from '../../store';
+  import { NavMode } from '../chartUtils';
 
   const dispatch = createEventDispatcher();
 
@@ -54,6 +56,8 @@
       loading = false;
       if (ds) {
         dispatch('imported', ds);
+        // reset viewport and make sure new data is displayed
+        $navMode = NavMode.autofit;
       } else {
         dispatch('close');
       }

--- a/src/components/tree/TreeLeafNode.svelte
+++ b/src/components/tree/TreeLeafNode.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import type DataSet from '../../data/DataSet';
-  import { activeDatasets, autoFit } from '../../store';
+  import { activeDatasets, navMode } from '../../store';
   import Fa from 'svelte-fa';
   import { faEyeSlash, faEye } from '@fortawesome/free-solid-svg-icons';
-  import type { IChart } from '../store';
+  import type { IChart } from '../../store';
+  import { NavMode } from '../chartUtils';
 
   export let node: DataSet;
   export let chart: IChart | null;
@@ -17,7 +18,7 @@
   }
   $: {
     // runs whenever $activeDatasets is updated
-    if ($activeDatasets && chart && $autoFit) {
+    if ($activeDatasets && chart && $navMode == NavMode.autofit) {
       chart.fitData(true);
     }
   }

--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -35,7 +35,6 @@ export interface SharedState {
   active: DataSet[];
   viewport: null | [number, number, number, number];
   showPoints: boolean;
-  autoFit: boolean;
 }
 
 const DEFAULT_VALUES: SharedState = {
@@ -43,7 +42,6 @@ const DEFAULT_VALUES: SharedState = {
   active: [],
   viewport: DEFAULT_VIEWPORT,
   showPoints: false,
-  autoFit: true,
 };
 
 const lookups = {

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,8 +15,7 @@ export const expandedDataGroups = writable([defaults.group]);
 
 export const isShowingPoints = writable(defaults.showPoints);
 export const initialViewport = writable(defaults.viewport);
-export const navMode = writable(NavMode.pan);
-export const autoFit = writable(defaults.autoFit);
+export const navMode = writable(NavMode.autofit);
 
 export function addDataSet(dataset: DataSet | DataGroup): void {
   const root = get(datasetTree);

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -50,21 +50,6 @@ tour.addStep({
 
 tour.addStep({
   attachTo: {
-    element: '[data-tour=browser]',
-    on: 'right',
-  },
-  title: 'Data Browser',
-  text: `<p>
-    The left panel shows the loaded datasets. It has several options to load new datasets, which are going to be explained as part of this tour.
-  </p>
-  <p>
-    The datasets are organized in a hierarchial structure. Each dataset can be individually shown in the chart by clicking on it.
-  </p>`,
-  buttons: nextCancel,
-});
-
-tour.addStep({
-  attachTo: {
     element: '[data-tour=chart]',
     on: 'top-start',
   },
@@ -84,6 +69,105 @@ tour.addStep({
   },
   title: 'Chart Menu',
   text: `The menu on top of the chart features several different options, such as changing colors or exporting the chart as an image.`,
+  buttons: nextCancel,
+});
+
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=navmode]',
+    on: 'auto',
+  },
+  title: 'Toggle between Navigation Modes',
+  text: `EpiVis supports four navigation modes. Autofit ensures that all enabled datasets are fully displayed on the chart; while Pan, Crop, and Zoom can be used to manipulate the view.`,
+  buttons: nextCancel,
+});
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=chart]',
+    on: 'bottom-end',
+  },
+  title: 'Mouse Panning',
+  text: `Pressing the mouse and dragging it will pan the view. Using the mouse wheel will zoom the view.`,
+  buttons: nextCancel,
+});
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=chart]',
+    on: 'bottom-end',
+  },
+  title: 'Mouse Cropping',
+  text: `Dragging the mouse while the <code>Shift</code> key is pressed will temporarily switch to the Crop navigation mode, which will span a rectangle of interest.`,
+  buttons: nextCancel,
+});
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=chart]',
+    on: 'bottom-end',
+  },
+  title: 'Mouse Zooming',
+  text: `Dragging the mouse while the <code>Ctrl/Control</code> key is pressed will temporarily switch to the zoom mode. Moving the mouse up will zoom in and down will zoom out in the value domain. Similarly, moving the mouse left or right will zoom in or out on the date domain.`,
+  buttons: nextCancel,
+});
+
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=random]',
+    on: 'auto',
+  },
+  title: 'Randomize Colors',
+  text: `This action will recolor all visible datasets. Keyboard Shortcut: r`,
+  buttons: nextCancel,
+});
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=fit]',
+    on: 'auto',
+  },
+  title: 'Fit Data to Screen',
+  text: `This action will changes the chart view such that all selected datasets are fully shown. Keyboard Shortcut: f`,
+  buttons: nextCancel,
+});
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=points]',
+    on: 'auto',
+  },
+  title: 'Toggle Point Rendering',
+  text: `This action will change whether points should be rendered representing individual data points of the time series. Keyboard Shortcut: s`,
+  buttons: nextCancel,
+});
+
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=screenshot]',
+    on: 'auto',
+  },
+  title: 'Download Screenshot',
+  text: `This action will download the current view in PNG format.`,
+  buttons: nextCancel,
+});
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=link]',
+    on: 'auto',
+  },
+  title: 'Create Shareable Link',
+  text: `This action will show a shareable link that can be used to reproduce the current view (if possible).`,
+  buttons: nextCancel,
+});
+
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=browser]',
+    on: 'right',
+  },
+  title: 'Data Browser',
+  text: `<p>
+    The left panel shows the loaded datasets. It has several options to load new datasets, which are going to be explained as part of this tour.
+  </p>
+  <p>
+    The datasets are organized in a hierarchial structure. Each dataset can be individually shown in the chart by clicking on it.
+  </p>`,
   buttons: nextCancel,
 });
 
@@ -124,98 +208,6 @@ tour.addStep({
   },
   title: 'Derive via a kernel function (Advanced)',
   text: `And another option is to derive one dataset by applying a kernel function to combine other datasets. For example, create a new dataset representing the average of two other datasets.`,
-  buttons: nextCancel,
-});
-
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=random]',
-    on: 'auto',
-  },
-  title: 'Randomize Colors',
-  text: `This action will recolor all visible datasets. Keyboard Shortcut: r`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=fit]',
-    on: 'auto',
-  },
-  title: 'Fit Data to Screen',
-  text: `This action will changes the chart view such that all selected datasets are fully shown. Keyboard Shortcut: f`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=autofit]',
-    on: 'auto',
-  },
-  title: 'Automatically Fit Data',
-  text: `This action changes whether the chart should be re-scaled every time a dataset is added or removed, to ensure all datasets are fully shown. Keyboard Shortcut: a`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=points]',
-    on: 'auto',
-  },
-  title: 'Toggle Point Rendering',
-  text: `This action will change whether points should be rendered representing individual data points of the time series. Keyboard Shortcut: s`,
-  buttons: nextCancel,
-});
-
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=screenshot]',
-    on: 'auto',
-  },
-  title: 'Download Screenshot',
-  text: `This action will download the current view in PNG format.`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=link]',
-    on: 'auto',
-  },
-  title: 'Create Shareable Link',
-  text: `This action will show a shareable link that can be used to reproduce the current view (if possible).`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=navmode]',
-    on: 'auto',
-  },
-  title: 'Toggle between Navigation Modes',
-  text: `EpiVis supports three navigation modes: Pan, Crop, and Zoom to manipulate the view.`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=chart]',
-    on: 'bottom-end',
-  },
-  title: 'Mouse Panning',
-  text: `Pressing the mouse and dragging it will pan the view. Using the mouse wheel will zoom the view.`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=chart]',
-    on: 'bottom-end',
-  },
-  title: 'Mouse Cropping',
-  text: `Dragging the mouse while the <code>Shift</code> key is pressed will temporarily switch to the Crop navigation mode, which will span a rectangle of interest.`,
-  buttons: nextCancel,
-});
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=chart]',
-    on: 'bottom-end',
-  },
-  title: 'Mouse Zooming',
-  text: `Dragging the mouse while the <code>Ctrl/Control</code> key is pressed will temporarily switch to the zoom mode. Moving the mouse up will zoom in and down will zoom out in the value domain. Similarly, moving the mouse left or right will zoom in or out on the date domain.`,
   buttons: nextCancel,
 });
 

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -64,26 +64,6 @@ tour.addStep({
 
 tour.addStep({
   attachTo: {
-    element: '[data-tour=top]',
-    on: 'auto',
-  },
-  title: 'Chart Menu',
-  text: `The menu on top of the chart features several different options, such as changing colors or exporting the chart as an image.`,
-  buttons: nextCancel,
-});
-
-tour.addStep({
-  attachTo: {
-    element: '[data-tour=navmode]',
-    on: 'auto',
-  },
-  title: 'Toggle between Navigation Modes',
-  text: `EpiVis supports four navigation modes. Autofit ensures that all enabled datasets are fully displayed on the chart; while Pan, Crop, and Zoom can be used to manipulate the view.`,
-  buttons: nextCancel,
-});
-
-tour.addStep({
-  attachTo: {
     element: '[data-tour=chart]',
     on: 'bottom-end',
   },
@@ -114,21 +94,31 @@ tour.addStep({
 
 tour.addStep({
   attachTo: {
-    element: '[data-tour=random]',
+    element: '[data-tour=top]',
     on: 'auto',
   },
-  title: 'Randomize Colors',
-  text: `This action will recolor all visible datasets. Keyboard Shortcut: r`,
+  title: 'Chart Menu',
+  text: `The menu on top of the chart features several different options, such as changing colors or exporting the chart as an image.`,
   buttons: nextCancel,
 });
 
 tour.addStep({
   attachTo: {
-    element: '[data-tour=fit]',
+    element: '[data-tour=navmode]',
     on: 'auto',
   },
-  title: 'Fit Data to Screen',
-  text: `This action will change the chart view such that all selected datasets are fully shown. Keyboard Shortcut: f`,
+  title: 'Toggle between Navigation Modes',
+  text: `EpiVis supports four navigation modes: Autofit (the default) ensures that all enabled datasets are fully displayed within the chart, while Pan, Crop, and Zoom can be used to manipulate the view.`,
+  buttons: nextCancel,
+});
+
+tour.addStep({
+  attachTo: {
+    element: '[data-tour=random]',
+    on: 'auto',
+  },
+  title: 'Randomize Colors',
+  text: `This action will recolor all visible datasets. Keyboard Shortcut: r`,
   buttons: nextCancel,
 });
 

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -81,6 +81,7 @@ tour.addStep({
   text: `EpiVis supports four navigation modes. Autofit ensures that all enabled datasets are fully displayed on the chart; while Pan, Crop, and Zoom can be used to manipulate the view.`,
   buttons: nextCancel,
 });
+
 tour.addStep({
   attachTo: {
     element: '[data-tour=chart]',
@@ -90,6 +91,7 @@ tour.addStep({
   text: `Pressing the mouse and dragging it will pan the view. Using the mouse wheel will zoom the view.`,
   buttons: nextCancel,
 });
+
 tour.addStep({
   attachTo: {
     element: '[data-tour=chart]',
@@ -99,6 +101,7 @@ tour.addStep({
   text: `Dragging the mouse while the <code>Shift</code> key is pressed will temporarily switch to the Crop navigation mode, which will span a rectangle of interest.`,
   buttons: nextCancel,
 });
+
 tour.addStep({
   attachTo: {
     element: '[data-tour=chart]',
@@ -118,15 +121,17 @@ tour.addStep({
   text: `This action will recolor all visible datasets. Keyboard Shortcut: r`,
   buttons: nextCancel,
 });
+
 tour.addStep({
   attachTo: {
     element: '[data-tour=fit]',
     on: 'auto',
   },
   title: 'Fit Data to Screen',
-  text: `This action will changes the chart view such that all selected datasets are fully shown. Keyboard Shortcut: f`,
+  text: `This action will change the chart view such that all selected datasets are fully shown. Keyboard Shortcut: f`,
   buttons: nextCancel,
 });
+
 tour.addStep({
   attachTo: {
     element: '[data-tour=points]',
@@ -139,6 +144,16 @@ tour.addStep({
 
 tour.addStep({
   attachTo: {
+    element: '[data-tour=scale]',
+    on: 'auto',
+  },
+  title: 'Dataset Scaling',
+  text: `The "Scale by 1/mean" action will bring all currently enabled signals within a more similar range, while "Reset Dataset Scaling" will reset them to their actual magnitudes.`,
+  buttons: nextCancel,
+});
+
+tour.addStep({
+  attachTo: {
     element: '[data-tour=screenshot]',
     on: 'auto',
   },
@@ -146,6 +161,7 @@ tour.addStep({
   text: `This action will download the current view in PNG format.`,
   buttons: nextCancel,
 });
+
 tour.addStep({
   attachTo: {
     element: '[data-tour=link]',


### PR DESCRIPTION
Closes #44, closes #46:

- The autofitting feature added in #36 has been turned into a new navigation mode, which is enabled by default.
  - It is mutually exclusive with pan, scroll or crop modes - so once a user looks at a particular area of the chart, enabling or disabling signals will no longer reset their viewport.
  - Adding a new signal will reset the mode to "autofit" again. 
- The "Scale by 1/mean" and "Reset Dataset Scaling" buttons are moved into their own group, and given more appropriate icons. Also, navigation mode icons are now positioned on the top left of the screen.
- The introductory interactive tour has been re-ordered so that top menu items are explained first.