### PR TITLE
Add API key field to covidcast imports

### DIFF
--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -199,8 +199,9 @@ export function importCDC({ locations, auth }: { locations: string; auth?: strin
     {
       epiweeks: epiRange(firstEpiWeek.cdc, currentEpiWeek),
     },
-    { auth, locations },
+    { locations },
     ['total', 'num1', 'num2', 'num3', 'num4', 'num5', 'num6', 'num7', 'num8'],
+    auth,
   );
 }
 
@@ -355,7 +356,7 @@ export function importFluView({
     {
       epiweeks: epiRange(firstEpiWeek.fluview, currentEpiWeek),
     },
-    { regions, issues, lag, auth },
+    { regions, issues, lag },
     [
       'wili',
       'ili',
@@ -369,7 +370,7 @@ export function importFluView({
       'num_age_4',
       'num_age_5',
     ],
-    '',
+    auth,
     {
       wili: '%wILI',
       ili: '%ILI',
@@ -408,8 +409,9 @@ export function importGHT({
     {
       epiweeks: epiRange(firstEpiWeek.ght, currentEpiWeek),
     },
-    { auth, locations, query },
+    { locations, query },
     ['value'],
+    auth,
   );
 }
 
@@ -469,8 +471,9 @@ export function importQuidel({ auth, locations }: { auth: string; locations: str
     {
       epiweeks: epiRange(firstEpiWeek.quidel, currentEpiWeek),
     },
-    { auth, locations },
+    { locations },
     ['value'],
+    auth,
   );
 }
 export function importSensors({
@@ -491,8 +494,9 @@ export function importSensors({
     {
       epiweeks: epiRange(firstEpiWeek.sensors, currentEpiWeek),
     },
-    { auth, names, locations },
+    { names, locations },
     ['value'],
+    auth,
   );
 }
 // twtr
@@ -517,8 +521,9 @@ export function importTwitter({
       : {
           epiweeks: epiRange(firstEpiWeek.twitter, currentEpiWeek),
         },
-    { auth, locations, resolution },
+    { locations, resolution },
     ['num', 'total', 'percent'],
+    auth,
   );
 }
 export function importWiki({

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -369,6 +369,7 @@ export function importFluView({
       'num_age_4',
       'num_age_5',
     ],
+    '',
     {
       wili: '%wILI',
       ili: '%ILI',

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -156,7 +156,7 @@ export function loadDataSet(
 }
 
 export function fetchCOVIDcastMeta(
-  api_key = '',
+  api_key: string,
 ): Promise<{ geo_type: string; signal: string; data_source: string; time_type?: string }[]> {
   let url_string = ENDPOINT + `/covidcast_meta/`;
   if (api_key !== '') {

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -112,6 +112,7 @@ export function loadDataSet(
   fixedParams: Record<string, unknown>,
   userParams: Record<string, unknown>,
   columns: string[],
+  api_key = '',
 ): Promise<DataGroup | null> {
   const duplicates = get(expandedDataGroups).filter((d) => d.title == title);
   if (duplicates.length > 0) {
@@ -124,7 +125,11 @@ export function loadDataSet(
       )
       .then(() => null);
   }
-  const url = new URL(ENDPOINT + `/${endpoint}/`);
+  let url_string = ENDPOINT + `/${endpoint}/`;
+  if (api_key !== '') {
+    url_string += `?api_key=${api_key}`;
+  }
+  const url = new URL(url_string);
   const params = cleanParams(userParams);
   Object.entries(fixedParams).forEach(([key, value]) => {
     url.searchParams.set(key, String(value));
@@ -150,8 +155,12 @@ export function loadDataSet(
     });
 }
 
-export function fetchCOVIDcastMeta(): Promise<{ geo_type: string; signal: string; data_source: string }[]> {
-  const url = new URL(ENDPOINT + `/covidcast_meta/`);
+export function fetchCOVIDcastMeta(api_key = ''): Promise<{ geo_type: string; signal: string; data_source: string }[]> {
+  let url_string = ENDPOINT + `/covidcast_meta/`;
+  if (api_key !== '') {
+    url_string += `?api_key=${api_key}`;
+  }
+  const url = new URL(url_string);
   url.searchParams.set('format', 'json');
   return fetchImpl<{ geo_type: string; signal: string; data_source: string }[]>(url).catch((error) => {
     console.warn('failed fetching data', error);
@@ -179,12 +188,14 @@ export function importCOVIDcast({
   geo_value,
   signal,
   time_type = 'day',
+  api_key,
 }: {
   data_source: string;
   signal: string;
   time_type?: 'day';
   geo_type: string;
   geo_value: string;
+  api_key: string;
 }): Promise<DataGroup | null> {
   const title = `[API] Delphi CODIDcast: ${geo_value} ${signal} (${data_source})`;
   return loadDataSet(
@@ -196,6 +207,7 @@ export function importCOVIDcast({
     },
     { data_source, signal, time_type, geo_type, geo_value },
     ['value', 'stderr', 'sample_size'],
+    api_key,
   );
 }
 

--- a/src/components/dialogs/dataSources/COVIDcast.svelte
+++ b/src/components/dialogs/dataSources/COVIDcast.svelte
@@ -12,6 +12,8 @@
   let signal = '';
   let geo_type = '';
   let geo_value = '';
+  let form_key = '';
+  let invalid_key = false;
 
   let dataSources: (LabelValue & { signals: string[] })[] = [];
   let geoTypes: string[] = [];
@@ -25,8 +27,10 @@
   }
 
   function fetchMetadata() {
-    fetchCOVIDcastMeta((api_key = api_key)).then((res) => {
+    fetchCOVIDcastMeta((api_key = form_key)).then((res) => {
       if (res.length !== 0) {
+        invalid_key = false;
+        api_key = form_key; // API key is valid -> use it to fetch data later on
         geoTypes = [...new Set(res.map((d) => d.geo_type))];
         const byDataSource = new Map<string, LabelValue & { signals: string[] }>();
         for (const row of res) {
@@ -45,6 +49,8 @@
           entry.signals.sort();
         });
         dataSources = [...byDataSource.values()].sort((a, b) => a.value.localeCompare(b.value));
+      } else {
+        invalid_key = api_key != ''; // mark field as invalid, unless it's empty
       }
     });
   }
@@ -58,7 +64,26 @@
   }
 </script>
 
-<TextField id="{id}-api" label="API Key" name="api_key" on_change={() => fetchMetadata()} bind:value={api_key} />
+<div>
+  <label class="uk-form-label" for="{id}-api">
+    <a href="https://cmu-delphi.github.io/delphi-epidata/api/api_keys.html">API Key</a> (optional)
+  </label>
+  <div class="uk-form-controls">
+    <input
+      id="{id}-api"
+      type="text"
+      class="uk-input"
+      class:uk-form-danger={invalid_key}
+      name="api_key"
+      required={false}
+      bind:value={form_key}
+      on:change={() => fetchMetadata()}
+    />
+    {#if invalid_key}
+      <div class="invalid">API key is invalid - ignoring</div>
+    {/if}
+  </div>
+</div>
 <SelectField id="{id}-r" label="Data Source" name="data_source" bind:value={data_source} options={dataSources} />
 <SelectField id="{id}-r" label="Data Signal" name="signal" bind:value={signal} options={dataSignals} />
 <SelectField id="{id}-gt" label="Geographic Type" bind:value={geo_type} name="geo_type" options={geoTypes} />
@@ -69,3 +94,10 @@
   name="geo_values"
   placeholder="e.g., PA or 42003"
 />
+
+<style>
+  .invalid {
+    color: red;
+    font-size: 0.75rem;
+  }
+</style>

--- a/src/components/dialogs/dataSources/COVIDcast.svelte
+++ b/src/components/dialogs/dataSources/COVIDcast.svelte
@@ -38,7 +38,7 @@
   function fetchMetadata() {
     fetchCOVIDcastMeta(form_key).then((res) => {
       if (res.length == 0) {
-        valid_key = form_key == ''; // mark key as valid if it's empty, otherwise invalid
+        valid_key = false;
       } else {
         valid_key = true;
         api_key = form_key; // API key is valid -> use it to fetch data later on

--- a/src/components/dialogs/dataSources/COVIDcast.svelte
+++ b/src/components/dialogs/dataSources/COVIDcast.svelte
@@ -60,7 +60,7 @@
   });
 
   export function importDataSet() {
-    return fetchCOVIDcastMeta().then((res) => {
+    return fetchCOVIDcastMeta((api_key = api_key)).then((res) => {
       const meta = res.filter((row) => row.data_source === data_source && row.signal === signal);
       const time_type = meta[0].time_type;
       return importCOVIDcast({ data_source, signal, geo_type, geo_value, time_type, api_key });

--- a/src/components/dialogs/inputs/TextField.svelte
+++ b/src/components/dialogs/inputs/TextField.svelte
@@ -5,11 +5,12 @@
   export let value: string;
   export let placeholder = '';
   export let required = true;
+  export let on_change: () => void = () => {};
 </script>
 
 <div>
   <label class="uk-form-label" for={id}>{label}</label>
   <div class="uk-form-controls">
-    <input type="text" class="uk-input" {name} {required} {id} bind:value {placeholder} />
+    <input type="text" class="uk-input" {name} {required} {id} bind:value on:change={on_change} {placeholder} />
   </div>
 </div>

--- a/src/components/dialogs/inputs/TextField.svelte
+++ b/src/components/dialogs/inputs/TextField.svelte
@@ -5,12 +5,11 @@
   export let value: string;
   export let placeholder = '';
   export let required = true;
-  export let on_change: () => void = () => {};
 </script>
 
 <div>
   <label class="uk-form-label" for={id}>{label}</label>
   <div class="uk-form-controls">
-    <input type="text" class="uk-input" {name} {required} {id} bind:value on:change={on_change} {placeholder} />
+    <input type="text" class="uk-input" {name} {required} {id} bind:value {placeholder} />
   </div>
 </div>


### PR DESCRIPTION
Closes #47:

- Adds an API key field to the COVIDCast signal import dialog.
- This displays previously hidden private signals in the dropdown, making them available for visualization.