### PR TITLE
Fix empty datasets locking UI

### DIFF
--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -139,7 +139,6 @@ export function loadDataSet(
     .then((res) => {
       const data = loadEpidata(title, res, columns, { _endpoint: endpoint, ...params });
       if (data.datasets.length == 0) {
-        console.warn('empty datasets');
         return UIkit.modal
           .alert(
             `

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -91,7 +91,9 @@ function loadEpidata(
       }
       points.push(new EpiPoint(date, row[col] as number));
     }
-    datasets.push(new DataSet(points, col, params));
+    if (points.length > 0) {
+      datasets.push(new DataSet(points, col, params));
+    }
   }
   return new DataGroup(name, datasets);
 }
@@ -135,7 +137,19 @@ export function loadDataSet(
   url.searchParams.set('format', 'json');
   return fetchImpl<Record<string, unknown>[]>(url)
     .then((res) => {
-      return loadEpidata(title, res, columns, { _endpoint: endpoint, ...params });
+      const data = loadEpidata(title, res, columns, { _endpoint: endpoint, ...params });
+      if (data.datasets.length == 0) {
+        console.warn('empty datasets');
+        return UIkit.modal
+          .alert(
+            `
+        <div class="uk-alert uk-alert-error">
+          <a href="${url.href}">API Link</a> returned no data.
+        </div>`,
+          )
+          .then(() => null);
+      }
+      return data;
     })
     .catch((error) => {
       console.warn('failed fetching data', error);


### PR DESCRIPTION
Closes #61.

During a data import, if a column has no data, excludes it from the visualization.
If *all* columns are excluded this way, omits the dataset entirely.