### PR TITLE
Improve behavior on errors when importing a dataset

### DIFF
--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -191,7 +191,7 @@ export function loadDataSet(
           .alert(
             `
         <div class="uk-alert uk-alert-error">
-          Failed to fetch API data from <a href="${url.href}">API Link</a>.
+          Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${error}</i>
         </div>`,
           )
           .then(() => null);

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -48,7 +48,13 @@ export function fetchImpl<T>(url: URL): Promise<T> {
   const urlGetS = url.toString();
   if (urlGetS.length < 4096) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return fetch(url.toString(), fetchOptions).then((d) => d.json());
+    return fetch(url.toString(), fetchOptions).then((d) => {
+      try {
+        return d.json();
+      } catch (error) {
+        throw new Error(`[${d.status}] ${d.text()}`);
+      }
+    });
   }
   const params = new URLSearchParams(url.searchParams);
   url.searchParams.forEach((d) => url.searchParams.delete(d));
@@ -57,7 +63,13 @@ export function fetchImpl<T>(url: URL): Promise<T> {
     ...fetchOptions,
     method: 'POST',
     body: params,
-  }).then((d) => d.json());
+  }).then((d) => {
+    try {
+      return d.json();
+    } catch (error) {
+      throw new Error(`[${d.status}] ${d.text()}`);
+    }
+  });
 }
 
 // generic epidata loader
@@ -155,7 +167,7 @@ export function loadDataSet(
             .alert(
               `
         <div class="uk-alert uk-alert-error">
-          <a href="${url.href}">API Link</a> returned no data.
+          <a href="${url.href}">API Link</a> returned no data, which suggests that the API has no available information for the selected location.
         </div>`,
             )
             .then(() => null);

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -183,7 +183,7 @@ export function loadDataSet(
             .alert(
               `
           <div class="uk-alert uk-alert-error">
-            Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${res['message']}</i>
+            [f01] Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${res['message']}</i>
           </div>`,
             )
             .then(() => null);
@@ -193,7 +193,7 @@ export function loadDataSet(
           .alert(
             `
         <div class="uk-alert uk-alert-error">
-          Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${error}</i>
+          [f02] Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${error}</i>
         </div>`,
           )
           .then(() => null);
@@ -205,7 +205,7 @@ export function loadDataSet(
         .alert(
           `
       <div class="uk-alert uk-alert-error">
-        Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${error}</i>
+        [f03] Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${error}</i>
       </div>`,
         )
         .then(() => null);

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -164,7 +164,7 @@ export function loadDataSet(
             .alert(
               `
           <div class="uk-alert uk-alert-error">
-            Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/>${res['message']}
+            Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${res['message']}</i>
           </div>`,
             )
             .then(() => null);

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -205,7 +205,7 @@ export function loadDataSet(
         .alert(
           `
       <div class="uk-alert uk-alert-error">
-        Failed to fetch API data from <a href="${url.href}">API Link</a>.
+        Failed to fetch API data from <a href="${url.href}">API Link</a>:<br/><i>${error}</i>
       </div>`,
         )
         .then(() => null);

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -44,16 +44,26 @@ const ENDPOINT = process.env.EPIDATA_ENDPOINT_URL;
 
 export const fetchOptions: RequestInit = process.env.NODE_ENV === 'development' ? { cache: 'force-cache' } : {};
 
+function processResponse<T>(response: Response): Promise<T> {
+  try {
+    if (response.status == 429) {
+      throw new Error(
+        'Rate limit exceeded for anonymous queries. To remove this limit, register a free API key at https://api.delphi.cmu.edu/epidata/admin/registration_form</p>',
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return response.json();
+  } catch (error) {
+    throw new Error(`[${response.status}] ${response.text()}`);
+  }
+}
+
 export function fetchImpl<T>(url: URL): Promise<T> {
   const urlGetS = url.toString();
   if (urlGetS.length < 4096) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return fetch(url.toString(), fetchOptions).then((d) => {
-      try {
-        return d.json();
-      } catch (error) {
-        throw new Error(`[${d.status}] ${d.text()}`);
-      }
+      return processResponse(d);
     });
   }
   const params = new URLSearchParams(url.searchParams);
@@ -64,11 +74,7 @@ export function fetchImpl<T>(url: URL): Promise<T> {
     method: 'POST',
     body: params,
   }).then((d) => {
-    try {
-      return d.json();
-    } catch (error) {
-      throw new Error(`[${d.status}] ${d.text()}`);
-    }
+    return processResponse(d);
   });
 }
 


### PR DESCRIPTION
Closes #45.

In the Import Dataset dialogue, displays the errors from the EpiData API to the user if one is present:

<img width="613" alt="Screenshot 2024-10-11 at 17 03 30" src="https://github.com/user-attachments/assets/5933acb5-9769-4cec-b97b-9dfebd5b7f4d">
