### PR TITLE
Derive custom titles from URL params

### DIFF
--- a/src/data/DataSet.ts
+++ b/src/data/DataSet.ts
@@ -28,6 +28,7 @@ export default class DataSet {
     public readonly data: readonly EpiPoint[],
     public title = '',
     public readonly params: Record<string, unknown> | unknown[] | null = null,
+    public customTitle: string | null = null,
     public color = getRandomColor(),
   ) {
     this.gap = computeGap(data);

--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -130,9 +130,9 @@ export function initialLoader(datasets: ILinkConfig['datasets']) {
       }
     }
 
+    /* eslint-disable @typescript-eslint/restrict-template-expressions */
     function resolveTitle(title: string, params: Record<string, unknown>) {
       let customTitle = title;
-      /* eslint-disable @typescript-eslint/restrict-template-expressions */
       if (params.custom_title) {
         // Custom title present (e.g. from signal documentation) - apply directly
         customTitle = `${params.custom_title}`;
@@ -150,9 +150,9 @@ export function initialLoader(datasets: ILinkConfig['datasets']) {
         }
         customTitle += ` > ${title}`;
       }
-      /* eslint-enable @typescript-eslint/restrict-template-expressions */
       customTitles.set(title, customTitle);
     }
+    /* eslint-enable @typescript-eslint/restrict-template-expressions */
 
     for (const ds of datasets) {
       if (ds.params && ds.params._type === 'line') {
@@ -169,8 +169,8 @@ export function initialLoader(datasets: ILinkConfig['datasets']) {
         resolvedDataSets.push(d);
         continue;
       }
+      resolveTitle(ds.title, ds.params);
       if (ds.params && ds.params._endpoint) {
-        resolveTitle(ds.title, ds.params);
         loadImpl(ds.title, ds.color, ds.params._endpoint as string, ds.params);
       } else if (ds.params && Array.isArray(ds.params)) {
         // old version


### PR DESCRIPTION
See https://github.com/cmu-delphi/www-epivis/issues/42#issuecomment-2492617632:

> Accepts a new optional field (called `custom_title`) in any signal entry found in the JSON structure that is encoded in sharable epivis URLs. When this field is present, the specified value should override the normal signal title.