### PR TITLE
Set `defaultEnabled` explicitly instead of passing thru call chain

### DIFF
--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -260,7 +260,7 @@ export function importCOVIDcast({
   api_key: string;
 }): Promise<DataGroup | null> {
   const title = `[API] COVIDcast: ${data_source}:${signal} (${geo_type}:${geo_value})`;
-  const ds = loadDataSet(
+  return loadDataSet(
     title,
     'covidcast',
     {
@@ -273,9 +273,11 @@ export function importCOVIDcast({
     { data_source, signal, time_type, geo_type, geo_value },
     ['value', 'stderr', 'sample_size'],
     api_key,
-  );
-  ds.defaultEnabled = ['value'];
-  return ds;
+  ).then((ds) => {
+    if (ds instanceof DataGroup) {
+      ds.defaultEnabled = ['value'];
+    }
+  };
 }
 
 export function importCOVIDHosp({
@@ -391,7 +393,7 @@ export function importFluView({
 }): Promise<DataGroup | null> {
   const regionLabel = fluViewRegions.find((d) => d.value === regions)?.label ?? '?';
   const title = appendIssueToTitle(`[API] ILINet (aka FluView): ${regionLabel}`, { issues, lag });
-  const ds = loadDataSet(
+  return loadDataSet(
     title,
     'fluview',
     {
@@ -416,9 +418,11 @@ export function importFluView({
       wili: '%wILI',
       ili: '%ILI',
     },
-  );
-  ds.defaultEnabled = ['%wILI'];
-  return ds;
+  ).then((ds) => {
+    if (ds instanceof DataGroup) {
+      ds.defaultEnabled = ['%wILI'];
+    }
+  }
 }
 
 export function importGFT({ locations }: { locations: string }): Promise<DataGroup | null> {

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -277,7 +277,7 @@ export function importCOVIDcast({
     if (ds instanceof DataGroup) {
       ds.defaultEnabled = ['value'];
     }
-  };
+  });
 }
 
 export function importCOVIDHosp({
@@ -422,7 +422,7 @@ export function importFluView({
     if (ds instanceof DataGroup) {
       ds.defaultEnabled = ['%wILI'];
     }
-  }
+  });
 }
 
 export function importGFT({ locations }: { locations: string }): Promise<DataGroup | null> {

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -277,6 +277,7 @@ export function importCOVIDcast({
     if (ds instanceof DataGroup) {
       ds.defaultEnabled = ['value'];
     }
+    return ds;
   });
 }
 
@@ -422,6 +423,7 @@ export function importFluView({
     if (ds instanceof DataGroup) {
       ds.defaultEnabled = ['%wILI'];
     }
+    return ds;
   });
 }
 

--- a/src/api/EpiData.ts
+++ b/src/api/EpiData.ts
@@ -274,6 +274,8 @@ export function importCOVIDcast({
     ['value', 'stderr', 'sample_size'],
     api_key,
   ).then((ds) => {
+    // get inside the Promise and make sure its not null,
+    // then enable display of 'value' data
     if (ds instanceof DataGroup) {
       ds.defaultEnabled = ['value'];
     }
@@ -420,6 +422,8 @@ export function importFluView({
       ili: '%ILI',
     },
   ).then((ds) => {
+    // get inside the Promise and make sure its not null,
+    // then enable display of 'percent weighted ILI' data
     if (ds instanceof DataGroup) {
       ds.defaultEnabled = ['%wILI'];
     }

--- a/src/data/DataSet.ts
+++ b/src/data/DataSet.ts
@@ -102,6 +102,7 @@ export default class DataSet {
 
 export class DataGroup {
   public parent?: DataGroup;
+  // which fields of this DataGroup should be "enabled" (shown/displayed) on load:
   public defaultEnabled: string[] = [];
 
   constructor(public readonly title: string, public readonly datasets: (DataSet | DataGroup)[]) {}

--- a/src/data/DataSet.ts
+++ b/src/data/DataSet.ts
@@ -105,9 +105,7 @@ export class DataGroup {
   public defaultEnabled: string[] = [];
 
   constructor(
-    public readonly title: string,
-    public readonly datasets: (DataSet | DataGroup)[],
-  ) {}
+    public readonly title: string, public readonly datasets: (DataSet | DataGroup)[]) {}
 
   flat(arr: DataSet[]): void {
     for (const child of this.datasets) {

--- a/src/data/DataSet.ts
+++ b/src/data/DataSet.ts
@@ -104,8 +104,7 @@ export class DataGroup {
   public parent?: DataGroup;
   public defaultEnabled: string[] = [];
 
-  constructor(
-    public readonly title: string, public readonly datasets: (DataSet | DataGroup)[]) {}
+  constructor(public readonly title: string, public readonly datasets: (DataSet | DataGroup)[]) {}
 
   flat(arr: DataSet[]): void {
     for (const child of this.datasets) {

--- a/src/data/DataSet.ts
+++ b/src/data/DataSet.ts
@@ -102,11 +102,11 @@ export default class DataSet {
 
 export class DataGroup {
   public parent?: DataGroup;
+  public defaultEnabled: string[] = [];
 
   constructor(
     public readonly title: string,
     public readonly datasets: (DataSet | DataGroup)[],
-    public readonly defaultEnabled: string[] = [],
   ) {}
 
   flat(arr: DataSet[]): void {


### PR DESCRIPTION
* attempting some suggestions on top of #90 

Sets `.defaultEnabled` at the end of `importXYZEndpoint()` methods instead of passing all the way through calls to `loadEpidata()` and `loadDataSet()` and constructor for `DataGroup`.