### PR TITLE
fix API key persistence

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -37,14 +37,14 @@ formSelections.subscribe((val) => {
 
 console.log(
   'before:',
-  localStorage.getItem('store-api-key'),
-  localStorage.getItem('api-key'),
-  sessionStorage.getItem('api-key'),
+  JSON.stringify(localStorage.getItem('store-api-key')),
+  JSON.stringify(localStorage.getItem('api-key')),
+  JSON.stringify(sessionStorage.getItem('api-key')),
 );
 
 export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
 storeApiKeys.subscribe((val) => {
-  console.log('storeApiKeys:', val);
+  console.log('storeApiKeys:', JSON.stringify(val));
   localStorage.setItem('store-api-key', val.toString());
   if (val) {
     // persist key from session to local storage
@@ -59,7 +59,7 @@ storeApiKeys.subscribe((val) => {
 sessionStorage.setItem('api-key', localStorage.getItem('api-key') || '');
 export const apiKey = writable(sessionStorage.getItem('api-key')!);
 apiKey.subscribe((val) => {
-  console.log('apiKey:', val);
+  console.log('apiKey:', JSON.stringify(val));
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);
   if (localStorage.getItem('store-api-key') === 'true') {
@@ -70,9 +70,9 @@ apiKey.subscribe((val) => {
 
 console.log(
   'after:',
-  localStorage.getItem('store-api-key'),
-  localStorage.getItem('api-key'),
-  sessionStorage.getItem('api-key'),
+  JSON.stringify(localStorage.getItem('store-api-key')),
+  JSON.stringify(localStorage.getItem('api-key')),
+  JSON.stringify(sessionStorage.getItem('api-key')),
 );
 
 export function addDataSet(dataset: DataSet | DataGroup): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,8 +48,8 @@ storeApiKeys.subscribe((val) => {
 });
 
 // ensure an appropriate value is in session storage on page load:
-sessionStorage.setItem('api-key', localStorage.getItem('api-key')! || '');
-export const apiKey = writable(sessionStorage.getItem('api-key'));
+sessionStorage.setItem('api-key', localStorage.getItem('api-key') || '');
+export const apiKey = writable(sessionStorage.getItem('api-key')!);
 apiKey.subscribe((val) => {
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,7 +39,7 @@ console.log(
   "before:",
   localStorage.getItem('store-api-key'),
   localStorage.getItem('api-key'),
-  sessionStorage.getItem('api-key')
+  sessionStorage.getItem('api-key'),
 );
 
 export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
@@ -72,7 +72,7 @@ console.log(
   "after:",
   localStorage.getItem('store-api-key'),
   localStorage.getItem('api-key'),
-  sessionStorage.getItem('api-key')
+  sessionStorage.getItem('api-key'),
 );
 
 export function addDataSet(dataset: DataSet | DataGroup): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,9 +37,9 @@ formSelections.subscribe((val) => {
 
 console.log(
   "before:",
-  localStorage.getItem('store-api-key'),
-  localStorage.getItem('api-key'),
-  sessionStorage.getItem('api-key'),
+  localStorage.getItem("store-api-key"),
+  localStorage.getItem("api-key"),
+  sessionStorage.getItem("api-key"),
 );
 
 export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
@@ -70,9 +70,9 @@ apiKey.subscribe((val) => {
 
 console.log(
   "after:",
-  localStorage.getItem('store-api-key'),
-  localStorage.getItem('api-key'),
-  sessionStorage.getItem('api-key'),
+  localStorage.getItem("store-api-key"),
+  localStorage.getItem("api-key"),
+  sessionStorage.getItem("api-key"),
 );
 
 export function addDataSet(dataset: DataSet | DataGroup): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,11 +48,13 @@ storeApiKeys.subscribe((val) => {
 });
 
 export const apiKey = writable(localStorage.getItem('api-key')! || '');
+// ensure an appropriate value is in session storage on page load:
+sessionStorage.setItem('api-key', apiKey);
 apiKey.subscribe((val) => {
-  // always keep key around in session storage (resets on page refresh)
+  // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);
   if (localStorage.getItem('store-api-key') === 'true') {
-    // store it in local storage (persistent)
+    // if flag set, also store it in local persistent storage
     localStorage.setItem('api-key', val);
   }
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -35,18 +35,8 @@ formSelections.subscribe((val) => {
   sessionStorage.setItem('form', JSON.stringify(val));
 });
 
-console.log(
-  'before:',
-  JSON.stringify(localStorage.getItem('store-api-key')),
-  JSON.stringify(localStorage.getItem('api-key')),
-  JSON.stringify(sessionStorage.getItem('api-key')),
-);
-
-// ensure an appropriate value is in session storage on page load:
-sessionStorage.setItem('api-key', localStorage.getItem('api-key') || '');
-export const apiKey = writable(sessionStorage.getItem('api-key')!);
+export const apiKey = writable(localStorage.getItem('api-key')! || '');
 apiKey.subscribe((val) => {
-  console.log('apiKey:', JSON.stringify(val));
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);
   if (localStorage.getItem('store-api-key') === 'true') {
@@ -57,7 +47,6 @@ apiKey.subscribe((val) => {
 
 export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
 storeApiKeys.subscribe((val) => {
-  console.log('storeApiKeys:', JSON.stringify(val));
   localStorage.setItem('store-api-key', val.toString());
   if (val) {
     // persist key from session to local storage
@@ -67,13 +56,6 @@ storeApiKeys.subscribe((val) => {
     localStorage.removeItem('api-key');
   }
 });
-
-console.log(
-  'after:',
-  JSON.stringify(localStorage.getItem('store-api-key')),
-  JSON.stringify(localStorage.getItem('api-key')),
-  JSON.stringify(sessionStorage.getItem('api-key')),
-);
 
 export function addDataSet(dataset: DataSet | DataGroup): void {
   const root = get(datasetTree);

--- a/src/store.ts
+++ b/src/store.ts
@@ -35,8 +35,16 @@ formSelections.subscribe((val) => {
   sessionStorage.setItem('form', JSON.stringify(val));
 });
 
+console.log(
+  "before:",
+  localStorage.getItem('store-api-key'),
+  localStorage.getItem('api-key'),
+  sessionStorage.getItem('api-key')
+);
+
 export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
 storeApiKeys.subscribe((val) => {
+  console.log("storeApiKeys:", val);
   localStorage.setItem('store-api-key', val.toString());
   if (val) {
     // persist key from session to local storage
@@ -51,6 +59,7 @@ storeApiKeys.subscribe((val) => {
 sessionStorage.setItem('api-key', localStorage.getItem('api-key') || '');
 export const apiKey = writable(sessionStorage.getItem('api-key')!);
 apiKey.subscribe((val) => {
+  console.log("apiKey:", val);
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);
   if (localStorage.getItem('store-api-key') === 'true') {
@@ -58,6 +67,13 @@ apiKey.subscribe((val) => {
     localStorage.setItem('api-key', val);
   }
 });
+
+console.log(
+  "after:",
+  localStorage.getItem('store-api-key'),
+  localStorage.getItem('api-key'),
+  sessionStorage.getItem('api-key')
+);
 
 export function addDataSet(dataset: DataSet | DataGroup): void {
   const root = get(datasetTree);

--- a/src/store.ts
+++ b/src/store.ts
@@ -47,9 +47,9 @@ storeApiKeys.subscribe((val) => {
   }
 });
 
-export const apiKey = writable(localStorage.getItem('api-key')! || '');
 // ensure an appropriate value is in session storage on page load:
-sessionStorage.setItem('api-key', $apiKey as string);
+sessionStorage.setItem('api-key', localStorage.getItem('api-key')! || '');
+export const apiKey = writable(sessionStorage.getItem('api-key'));
 apiKey.subscribe((val) => {
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);

--- a/src/store.ts
+++ b/src/store.ts
@@ -42,19 +42,6 @@ console.log(
   JSON.stringify(sessionStorage.getItem('api-key')),
 );
 
-export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
-storeApiKeys.subscribe((val) => {
-  console.log('storeApiKeys:', JSON.stringify(val));
-  localStorage.setItem('store-api-key', val.toString());
-  if (val) {
-    // persist key from session to local storage
-    localStorage.setItem('api-key', sessionStorage.getItem('api-key') || '');
-  } else {
-    // remove key from local storage
-    localStorage.removeItem('api-key');
-  }
-});
-
 // ensure an appropriate value is in session storage on page load:
 sessionStorage.setItem('api-key', localStorage.getItem('api-key') || '');
 export const apiKey = writable(sessionStorage.getItem('api-key')!);
@@ -65,6 +52,19 @@ apiKey.subscribe((val) => {
   if (localStorage.getItem('store-api-key') === 'true') {
     // if flag set, also store key in local persistent storage
     localStorage.setItem('api-key', val);
+  }
+});
+
+export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
+storeApiKeys.subscribe((val) => {
+  console.log('storeApiKeys:', JSON.stringify(val));
+  localStorage.setItem('store-api-key', val.toString());
+  if (val) {
+    // persist key from session to local storage
+    localStorage.setItem('api-key', sessionStorage.getItem('api-key') || '');
+  } else {
+    // remove key from local storage
+    localStorage.removeItem('api-key');
   }
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -47,7 +47,7 @@ storeApiKeys.subscribe((val) => {
   }
 });
 
-export const apiKey = writable(localStorage.getItem('api-key')! || '');
+export const apiKey = writable<string>(localStorage.getItem('api-key')! || '');
 // ensure an appropriate value is in session storage on page load:
 sessionStorage.setItem('api-key', $apiKey);
 apiKey.subscribe((val) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,7 +54,7 @@ apiKey.subscribe((val) => {
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);
   if (localStorage.getItem('store-api-key') === 'true') {
-    // if flag set, also store it in local persistent storage
+    // if flag set, also store key in local persistent storage
     localStorage.setItem('api-key', val);
   }
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -47,9 +47,9 @@ storeApiKeys.subscribe((val) => {
   }
 });
 
-export const apiKey = writable<string>(localStorage.getItem('api-key')! || '');
+export const apiKey = writable(localStorage.getItem('api-key')! || '');
 // ensure an appropriate value is in session storage on page load:
-sessionStorage.setItem('api-key', $apiKey);
+sessionStorage.setItem('api-key', $apiKey as string);
 apiKey.subscribe((val) => {
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,15 +36,15 @@ formSelections.subscribe((val) => {
 });
 
 console.log(
-  "before:",
-  localStorage.getItem("store-api-key"),
-  localStorage.getItem("api-key"),
-  sessionStorage.getItem("api-key"),
+  'before:',
+  localStorage.getItem('store-api-key'),
+  localStorage.getItem('api-key'),
+  sessionStorage.getItem('api-key'),
 );
 
 export const storeApiKeys = writable(localStorage.getItem('store-api-key') === 'true');
 storeApiKeys.subscribe((val) => {
-  console.log("storeApiKeys:", val);
+  console.log('storeApiKeys:', val);
   localStorage.setItem('store-api-key', val.toString());
   if (val) {
     // persist key from session to local storage
@@ -59,7 +59,7 @@ storeApiKeys.subscribe((val) => {
 sessionStorage.setItem('api-key', localStorage.getItem('api-key') || '');
 export const apiKey = writable(sessionStorage.getItem('api-key')!);
 apiKey.subscribe((val) => {
-  console.log("apiKey:", val);
+  console.log('apiKey:', val);
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);
   if (localStorage.getItem('store-api-key') === 'true') {
@@ -69,10 +69,10 @@ apiKey.subscribe((val) => {
 });
 
 console.log(
-  "after:",
-  localStorage.getItem("store-api-key"),
-  localStorage.getItem("api-key"),
-  sessionStorage.getItem("api-key"),
+  'after:',
+  localStorage.getItem('store-api-key'),
+  localStorage.getItem('api-key'),
+  sessionStorage.getItem('api-key'),
 );
 
 export function addDataSet(dataset: DataSet | DataGroup): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -49,7 +49,7 @@ storeApiKeys.subscribe((val) => {
 
 export const apiKey = writable(localStorage.getItem('api-key')! || '');
 // ensure an appropriate value is in session storage on page load:
-sessionStorage.setItem('api-key', apiKey);
+sessionStorage.setItem('api-key', $apiKey);
 apiKey.subscribe((val) => {
   // always keep key in session storage (resets on window close)
   sessionStorage.setItem('api-key', val);


### PR DESCRIPTION
* for #97 

This swaps the evaluation order of the blocks for the svelte stores (and session/local storage) of 'api-key' and 'store-api-key'.  Also updates some comments a little.

Each of the stores' `.subscribe()` event handlers are called immediately after registration (w/ the initial value as an argument).  Because of that, prior to this PR, the "store api key flag" was processed before the "api key" was retrieved from persistent storage, thereby overwriting a previously saved api key with an empty value.  Now, a pre-existing api key is loaded before any attempt to save it back to persistent storage.