### PR TITLE
update covidcast 'firstDate'

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -392,6 +392,6 @@ export const firstEpiWeek = {
 export const firstDate = {
   twitter: 20111201,
   wiki: 20071209,
-  covidcast: 20200101,
+  covidcast: 20170815,
   covid_hosp: 20200101,
 };


### PR DESCRIPTION
update `firstDate` used with the covidcast endpoint, to account for new, recently backfilled google-symptoms data.

closes #92 

date references:
* https://github.com/cmu-delphi/covidcast-indicators/issues/2107#issuecomment-2612817063
* https://github.com/cmu-delphi/delphi-epidata/blob/65809bab5735cf3f4836ed5ce2cbeeb845c7745e/docs/api/covidcast-signals/google-symptoms.md?plain=1#L57-L71