### PR TITLE
Promote COVIDcast option in load dialog

### DIFF
--- a/src/components/dialogs/ImportAPIDialog.svelte
+++ b/src/components/dialogs/ImportAPIDialog.svelte
@@ -72,6 +72,16 @@
             type="radio"
             name="dataSource"
             bind:group={$formSelections.dataSource}
+            value="covidcast"
+          />
+          Delphi Indicators (aka COVIDcast) (source: <a target="_blank" href="https://delphi.cmu.edu/">delphi.cmu.edu</a>)</label
+        >
+        <label
+          ><input
+            class="uk-radio"
+            type="radio"
+            name="dataSource"
+            bind:group={$formSelections.dataSource}
             value="flusurv"
           />
           FluSurv (source:
@@ -164,16 +174,6 @@
             value="nowcast"
           />
           Delphi Nowcast (source: <a target="_blank" href="https://delphi.cmu.edu/">delphi.cmu.edu</a>)</label
-        >
-        <label
-          ><input
-            class="uk-radio"
-            type="radio"
-            name="dataSource"
-            bind:group={$formSelections.dataSource}
-            value="covidcast"
-          />
-          Delphi COVIDcast (source: <a target="_blank" href="https://delphi.cmu.edu/">delphi.cmu.edu</a>)</label
         >
         <label
           ><input


### PR DESCRIPTION
This PR moves the "COVIDcast" endpoint item to the 2nd position of the "Load from Epidata API" dialog.  It also hints at future renaming, and away from the COVID-specificity that it might suggest.

I moved it to the second in the list and not the first because the first is "ILINet (aka FluView)", which is still actively updated, it has a long historical record of data (it goes back to 1997!), and it is already used as the sample signal (on initial page load).

closes #75