### PR TITLE
add link to covidcast api docs

### DIFF
--- a/src/components/dialogs/ImportAPIDialog.svelte
+++ b/src/components/dialogs/ImportAPIDialog.svelte
@@ -75,7 +75,11 @@
             value="covidcast"
           />
           Delphi Indicators (aka COVIDcast) (docs:
-          <a target="_blank" href="https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html#all-available-sources-and-signals">cmu-delphi.github.io</a>)</label
+          <a
+            target="_blank"
+            href="https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html#all-available-sources-and-signals"
+            >cmu-delphi.github.io</a
+          >)</label
         >
         <label
           ><input

--- a/src/components/dialogs/ImportAPIDialog.svelte
+++ b/src/components/dialogs/ImportAPIDialog.svelte
@@ -74,8 +74,8 @@
             bind:group={$formSelections.dataSource}
             value="covidcast"
           />
-          Delphi Indicators (aka COVIDcast) (source:
-          <a target="_blank" href="https://delphi.cmu.edu/">delphi.cmu.edu</a>)</label
+          Delphi Indicators (aka COVIDcast) (docs:
+          <a target="_blank" href="https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html#all-available-sources-and-signals">cmu-delphi.github.io</a>)</label
         >
         <label
           ><input


### PR DESCRIPTION
This changes the link (in the "load from api" dialog box) to one for the covidcast API docs, instead of a link to the main delphi website.