### PR TITLE
honor the 'viewport' of direct links (dont autofit them away)

### DIFF
--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -220,7 +220,7 @@ export function getDirectLinkImpl(state: SharedState): { url: URL; anySkipped: b
   const config: ILinkConfig = {
     chart: {
       // if in autofit mode, pass null viewport, else preserve viewport (or default to 0s)
-      viewport: (state.navMode == NavMode.autofit) ? null : (state.viewport ?? [0, 0, 0, 0]),
+      viewport: state.navMode == NavMode.autofit ? null : state.viewport ?? [0, 0, 0, 0],
       showPoints: state.showPoints,
     },
     datasets: [],

--- a/src/deriveLinkDefaults.ts
+++ b/src/deriveLinkDefaults.ts
@@ -14,6 +14,7 @@ import {
   importTwitter,
   importWiki,
 } from './api/EpiData';
+import { NavMode } from './components/chartUtils';
 import DataSet, { DataGroup, DEFAULT_GROUP, flatten, DEFAULT_VIEWPORT } from './data/DataSet';
 import EpiDate from './data/EpiDate';
 import EpiPoint from './data/EpiPoint';
@@ -35,6 +36,7 @@ export interface SharedState {
   active: DataSet[];
   viewport: null | [number, number, number, number];
   showPoints: boolean;
+  navMode: NavMode;
 }
 
 const DEFAULT_VALUES: SharedState = {
@@ -42,6 +44,7 @@ const DEFAULT_VALUES: SharedState = {
   active: [],
   viewport: DEFAULT_VIEWPORT,
   showPoints: false,
+  navMode: NavMode.pan,
 };
 
 const lookups = {
@@ -202,6 +205,8 @@ export default function deriveLinkDefaults(): SharedState & { loader?: ReturnTyp
       active: [],
       showPoints: parsed.chart?.showPoints ?? DEFAULT_VALUES.showPoints,
       viewport: parsed.chart?.viewport ?? DEFAULT_VALUES.viewport,
+      // if we were not passed viewport coords, set to autofit mode
+      navMode: parsed.chart?.viewport ? DEFAULT_VALUES.navMode : NavMode.autofit,
       loader: initialLoader(parsed.datasets),
     };
   } catch (err) {
@@ -214,7 +219,8 @@ export default function deriveLinkDefaults(): SharedState & { loader?: ReturnTyp
 export function getDirectLinkImpl(state: SharedState): { url: URL; anySkipped: boolean } {
   const config: ILinkConfig = {
     chart: {
-      viewport: state.viewport ?? [0, 0, 0, 0],
+      // if in autofit mode, pass null viewport, else preserve viewport (or default to 0s)
+      viewport: (state.navMode == NavMode.autofit) ? null : (state.viewport ?? [0, 0, 0, 0]),
       showPoints: state.showPoints,
     },
     datasets: [],

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,4 @@
 import { get, writable } from 'svelte/store';
-import { NavMode } from './components/chartUtils';
 import DataSet, { DataGroup } from './data/DataSet';
 import deriveLinkDefaults, { getDirectLinkImpl } from './deriveLinkDefaults';
 import FormSelections from './components/dialogs/formSelections';
@@ -16,7 +15,7 @@ export const expandedDataGroups = writable([defaults.group]);
 
 export const isShowingPoints = writable(defaults.showPoints);
 export const initialViewport = writable(defaults.viewport);
-export const navMode = writable(NavMode.autofit);
+export const navMode = writable(defaults.navMode);
 
 export function getFormSelections() {
   try {
@@ -97,6 +96,7 @@ export function getDirectLink(chart: IChart): { url: URL; anySkipped: boolean } 
     active: get(activeDatasets),
     showPoints: get(isShowingPoints),
     viewport: chart.getViewport(),
+    navMode: get(navMode),
   });
 }
 


### PR DESCRIPTION
* closes #96 

Epivis direct links (with dataset information encoded in an epivis url) can include a "`viewport`" parameter that represents the graph axis extents at time of link generation.  The recently added "autofit" mode functionality broke this, by automatically zooming to see the entirety of all the current signals on load.  This PR should now restore the saved viewport when it is present, or default to autofit behavior when viewport is not provided in the URL.